### PR TITLE
Add conditional logic to "Create Deployment Marker" task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,7 @@
   tags: debug_info
 
 - name: Create Deployment Marker
+  when: length(new_relic_applications.json.applications) > 0
   uri:
     url: '{{ new_relic_api_base_url }}/applications/{{ new_relic_applications.json.applications[0].id }}/deployments.json'
     method: POST

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   tags: debug_info
 
 - name: Create Deployment Marker
-  when: length(new_relic_applications.json.applications) > 0
+  when: new_relic_applications.json.applications|length > 0
   uri:
     url: '{{ new_relic_api_base_url }}/applications/{{ new_relic_applications.json.applications[0].id }}/deployments.json'
     method: POST


### PR DESCRIPTION
Resolves #1 by skipping this task when the hosts are not monitored.